### PR TITLE
Handle "/implicit_login" endpoint

### DIFF
--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/lesterfernandez/roommate-finder/server/data"
 	"github.com/lesterfernandez/roommate-finder/server/token"
@@ -89,7 +90,30 @@ func LoginUser(w http.ResponseWriter, res *http.Request) {
 func HandleImplicitLogin(w http.ResponseWriter, res *http.Request) {
 	headers := res.Header
 	authHeader := headers.Get("Authentication")
-	fmt.Printf("AuthenticationHeader = %v\n", authHeader)
+
+	//Check if the Auth Header has valid format
+	if !strings.Contains(authHeader, " ") {
+		respondWithError(w, "Unauthorized Response", http.StatusUnauthorized)
+		return
+	}
+	//Split the `Bearer Token` string into an array, and extract the `Token`
+	splitAuthHeader := strings.Split(authHeader, " ")
+	JWT := splitAuthHeader[1]
+	claims, err := token.VerifyJWT(JWT, token.JWTKey)
+	if err != nil {
+		respondWithError(w, "Unauthorized Reponse; Invalid JWT", http.StatusUnauthorized)
+		return
+	}
+
+	//Send 200 OK http Status
+	w.WriteHeader(http.StatusOK)
+	fmt.Printf("Claims: %v\n", claims)
+	fmt.Printf("Claims Subject: %v\n", claims["sub"])
+
+	//Respond with RegisterBody JSON
+	// foundUser := data.FindUser(claims["sub"].(string))
+	// json.NewEncoder(w).Encode(foundUser)
+	// fmt.Println(*foundUser)
 
 }
 

--- a/server/handlers/handlers.go
+++ b/server/handlers/handlers.go
@@ -99,7 +99,7 @@ func HandleImplicitLogin(w http.ResponseWriter, res *http.Request) {
 	//Split the `Bearer Token` string into an array, and extract the `Token`
 	splitAuthHeader := strings.Split(authHeader, " ")
 	JWT := splitAuthHeader[1]
-	claims, err := token.VerifyJWT(JWT, token.JWTKey)
+	token, err := token.VerifyJWT(JWT, token.JWTKey)
 	if err != nil {
 		respondWithError(w, "Unauthorized Reponse; Invalid JWT", http.StatusUnauthorized)
 		return
@@ -107,12 +107,14 @@ func HandleImplicitLogin(w http.ResponseWriter, res *http.Request) {
 
 	//Send 200 OK http Status
 	w.WriteHeader(http.StatusOK)
-	fmt.Printf("Claims: %v\n", claims)
-	fmt.Printf("Claims Subject: %v\n", claims["sub"])
+	fmt.Printf("Claims: %v\n", token.Claims)
 
 	//Respond with RegisterBody JSON
-	// foundUser := data.FindUser(claims["sub"].(string))
-	// json.NewEncoder(w).Encode(foundUser)
+	//PROBABLY will result in error. GetUser replaced old findUser func
+	subject, _ := token.Claims.GetSubject()
+	foundUser := data.GetUser(subject)
+
+	json.NewEncoder(w).Encode(foundUser)
 	// fmt.Println(*foundUser)
 
 }

--- a/server/token/token.go
+++ b/server/token/token.go
@@ -43,20 +43,12 @@ func CreateJWT(username string) (string, error) {
 // Verify that a JWT is valid, and return the registeredClaims
 //========================================================================================================
 
-func VerifyJWT(tokenString string, secretKey []byte) (jwt.MapClaims, error) {
+func VerifyJWT(tokenString string, secretKey []byte) (*jwt.Token, error) {
 
-	//Verify that the signing method is correct
-	verifySigningMethod := func(token *jwt.Token) (interface{}, error) {
-		// Check the signing method
-		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
-			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
-		}
-		// Return the secret key for validation
+	//Verify the correct signing method is used (HS256)
+	token, err := jwt.Parse(tokenString, func(t *jwt.Token) (interface{}, error) {
 		return secretKey, nil
-	}
-
-	// Parse the JWT token using verifySigningMethod
-	token, err := jwt.Parse(tokenString, verifySigningMethod)
+	}, jwt.WithValidMethods([]string{"HS256"}))
 
 	if err != nil {
 		return nil, err
@@ -67,10 +59,5 @@ func VerifyJWT(tokenString string, secretKey []byte) (jwt.MapClaims, error) {
 		return nil, fmt.Errorf("token is not valid")
 	}
 
-	// Extract the claims from the token
-	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
-		return claims, nil
-	}
-
-	return nil, fmt.Errorf("failed to parse claims")
+	return token, nil
 }

--- a/server/token/token.go
+++ b/server/token/token.go
@@ -2,22 +2,31 @@ package token
 
 import (
 	"encoding/json"
+	"fmt"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/lesterfernandez/roommate-finder/server/data"
 	"net/http"
 	"time"
 )
 
-// Encode JWT Token into JSON
+var JWTKey = []byte("secret")
+
+//=====================================================================================
+// Encode JWT into JSON, send it as response
+//=====================================================================================
+
 func SendJWT(w http.ResponseWriter, jwt string) {
 	w.Header().Set("Application-Type", "application/json")
 	json.NewEncoder(w).Encode(data.TokenMessage{Token: jwt})
 }
 
-// Create JWT =====================================================================
+//=====================================================================================
+// Create JWT
+//=====================================================================================
+
 func CreateJWT(username string) (string, error) {
 
-	expirationTime := time.Now().Add(time.Minute * 5)
+	expirationTime := time.Now().Add(time.Minute * 1)
 
 	claims := &jwt.RegisteredClaims{
 		Subject:   username,
@@ -25,7 +34,43 @@ func CreateJWT(username string) (string, error) {
 	}
 
 	token := jwt.NewWithClaims(jwt.SigningMethodHS256, claims)
-	tokenString, err := token.SignedString(data.JWTKey)
+	tokenString, err := token.SignedString(JWTKey)
 
 	return tokenString, err
+}
+
+//========================================================================================================
+// Verify that a JWT is valid, and return the registeredClaims
+//========================================================================================================
+
+func VerifyJWT(tokenString string, secretKey []byte) (jwt.MapClaims, error) {
+
+	//Verify that the signing method is correct
+	verifySigningMethod := func(token *jwt.Token) (interface{}, error) {
+		// Check the signing method
+		if _, ok := token.Method.(*jwt.SigningMethodHMAC); !ok {
+			return nil, fmt.Errorf("unexpected signing method: %v", token.Header["alg"])
+		}
+		// Return the secret key for validation
+		return secretKey, nil
+	}
+
+	// Parse the JWT token using verifySigningMethod
+	token, err := jwt.Parse(tokenString, verifySigningMethod)
+
+	if err != nil {
+		return nil, err
+	}
+
+	// Verify if token is valid
+	if !token.Valid {
+		return nil, fmt.Errorf("token is not valid")
+	}
+
+	// Extract the claims from the token
+	if claims, ok := token.Claims.(jwt.MapClaims); ok && token.Valid {
+		return claims, nil
+	}
+
+	return nil, fmt.Errorf("failed to parse claims")
 }


### PR DESCRIPTION
## Summary
- Created `verifyJWT()` func
- Finished the `/implicit_login` handler, that verifies the AuthHeader and responds with `UserProfile` JSON.
- Created temporary `FindUser()` func in queries.go for tests
- Everything still works according to Mr. Postman
