### PR TITLE
change command that runs on precommit hook

### DIFF
--- a/client/.husky/pre-commit
+++ b/client/.husky/pre-commit
@@ -1,4 +1,4 @@
 #!/usr/bin/env sh
 . "$(dirname -- "$0")/_/husky.sh"
 
-cd client && npm run lint
+cd client && npm run lint-check


### PR DESCRIPTION
## Summary
Previously, `npm run lint` was executed as a precommit hook. Whenever a file had to be formatted or linted, the hook would do so, and the commit would succeed without the changes.

This PR changes the command ran to `npm run lint-check`. This will allow a commit to fail whenever formatting or linting warning/errors exist. 