### PR TITLE
improve errors import

### DIFF
--- a/server/go.mod
+++ b/server/go.mod
@@ -8,6 +8,7 @@ require (
 	github.com/gorilla/websocket v1.5.0
 	github.com/jackc/pgx/v5 v5.4.3
 	github.com/joho/godotenv v1.5.1
+	github.com/redis/go-redis/v9 v9.3.0
 	golang.org/x/crypto v0.13.0
 )
 
@@ -15,7 +16,6 @@ require (
 	github.com/cespare/xxhash/v2 v2.2.0 // indirect
 	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/jackc/puddle/v2 v2.2.1 // indirect
-	github.com/redis/go-redis/v9 v9.3.0 // indirect
 	golang.org/x/sync v0.1.0 // indirect
 )
 

--- a/server/go.sum
+++ b/server/go.sum
@@ -1,3 +1,5 @@
+github.com/bsm/ginkgo/v2 v2.12.0 h1:Ny8MWAHyOepLGlLKYmXG4IEkioBysk6GpaRTLC8zwWs=
+github.com/bsm/gomega v1.27.10 h1:yeMWxP2pV2fG3FgAODIY8EiRE3dy0aeFYt4l7wh6yKA=
 github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
 github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/server/handlers/chat.go
+++ b/server/handlers/chat.go
@@ -4,10 +4,11 @@ import (
 	"fmt"
 	"net/http"
 
+	"errors"
+
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/gorilla/websocket"
 	"github.com/lesterfernandez/roommate-finder/server/data"
-	"github.com/pkg/errors"
 )
 
 func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
We were importing `golang.org/pkg/errors`, but `errors` is part of the standard library. I changed that import.
Then, I ran `go mod tidy` and some changes occurred as well.