### PR TITLE
Fix Chat Handler not receiving context

### DIFF
--- a/server/handlers/chat.go
+++ b/server/handlers/chat.go
@@ -12,6 +12,7 @@ import (
 )
 
 func (s *Server) handleChat(w http.ResponseWriter, r *http.Request) {
+
 	upgrader := websocket.Upgrader{}
 	conn, err := upgrader.Upgrade(w, r, nil)
 	if err != nil {

--- a/server/handlers/handler.go
+++ b/server/handlers/handler.go
@@ -33,8 +33,14 @@ func CreateHandler(s *Server) http.Handler {
 
 		// Authenticated routes
 		r.Get("/search", s.searchUsers)
-		r.Get("/chat", s.handleChat)
 		r.Put("/profile", s.editProfile)
+	})
+
+	r.Group(func(r chi.Router) {
+		r.Use(AuthenticateWS)
+
+		r.Get("/chat", s.handleChat)
+
 	})
 
 	return r


### PR DESCRIPTION
## Summary

- Created middleware for the chat handler that passes the verified token through context
- This is because the WS required the token to be parsed from URL Parameters, and not through headers (like the other middleware)
