### PR TITLE
Allow all CORS origins

### DIFF
--- a/server/handlers/handler.go
+++ b/server/handlers/handler.go
@@ -17,7 +17,7 @@ func CreateHandler(s *Server) http.Handler {
 	r := chi.NewRouter()
 
 	c := cors.New(cors.Options{
-		AllowedOrigins:   []string{"http://localhost:5173"},
+		AllowedOrigins:   []string{"*"},
 		AllowedMethods:   []string{"POST", "PUT", "GET"},
 		AllowCredentials: true,
 		AllowedHeaders:   []string{"*"},


### PR DESCRIPTION
## Summary

- Allow all CORS origins in prep for when the site is hosted.
